### PR TITLE
fix EGIT_REPO_URI for the current gitorious.org site

### DIFF
--- a/dev-libs/k8json/k8json-9999.ebuild
+++ b/dev-libs/k8json/k8json-9999.ebuild
@@ -8,7 +8,7 @@ inherit cmake-utils git-2
 DESCRIPTION="Small and fast JSON parser (and primitive memory-hungry writter) \
 for Qt."
 HOMEPAGE="http://gitorious.org/k8jsonqt"
-EGIT_REPO_URI="git://gitorious.org/+qutim-developers/${PN}qt/qutim-developers-${PN}.git"
+EGIT_REPO_URI="https://gitorious.org/+qutim-developers/${PN}qt/qutim-developers-${PN}.git"
 
 LICENSE="GPL-2"
 SLOT="2"

--- a/dev-libs/libdbusmenu-qt/libdbusmenu-qt-0.9.0.ebuild
+++ b/dev-libs/libdbusmenu-qt/libdbusmenu-qt-0.9.0.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=4
 
-EGIT_REPO_URI="git://gitorious.org/dbusmenu/dbusmenu-qt.git"
+EGIT_REPO_URI="https://gitorious.org/dbusmenu/dbusmenu-qt.git"
 
 [[ ${PV} == 9999* ]] && GIT_ECLASS="git-2"
 inherit cmake-utils virtualx ${GIT_ECLASS}

--- a/dev-libs/libdbusmenu-qt/libdbusmenu-qt-0.9.1.ebuild
+++ b/dev-libs/libdbusmenu-qt/libdbusmenu-qt-0.9.1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=4
 
-EGIT_REPO_URI="git://gitorious.org/dbusmenu/dbusmenu-qt.git"
+EGIT_REPO_URI="https://gitorious.org/dbusmenu/dbusmenu-qt.git"
 
 [[ ${PV} == 9999* ]] && GIT_ECLASS="git-2"
 inherit cmake-utils virtualx ${GIT_ECLASS}

--- a/dev-libs/libdbusmenu-qt/libdbusmenu-qt-0.9.2-r2.ebuild
+++ b/dev-libs/libdbusmenu-qt/libdbusmenu-qt-0.9.2-r2.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=4
 
-EGIT_REPO_URI="git://gitorious.org/dbusmenu/dbusmenu-qt.git"
+EGIT_REPO_URI="https://gitorious.org/dbusmenu/dbusmenu-qt.git"
 
 [[ ${PV} == 9999* ]] && GIT_ECLASS="git-2"
 inherit cmake-utils virtualx ${GIT_ECLASS}

--- a/dev-libs/libdbusmenu-qt/libdbusmenu-qt-0.9.2.ebuild
+++ b/dev-libs/libdbusmenu-qt/libdbusmenu-qt-0.9.2.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=4
 
-EGIT_REPO_URI="git://gitorious.org/dbusmenu/dbusmenu-qt.git"
+EGIT_REPO_URI="https://gitorious.org/dbusmenu/dbusmenu-qt.git"
 
 [[ ${PV} == 9999* ]] && GIT_ECLASS="git-2"
 inherit cmake-utils virtualx ${GIT_ECLASS}

--- a/dev-util/qbs/qbs-9999.ebuild
+++ b/dev-util/qbs/qbs-9999.ebuild
@@ -6,7 +6,7 @@ EAPI="4"
 inherit qt4-r2 git-2
 
 HOMEPAGE="http://labs.qt.nokia.com/2012/02/15/introducing-qbs"
-EGIT_REPO_URI="git://gitorious.org/qt-labs/${PN}.git"
+EGIT_REPO_URI="https://gitorious.org/qt-labs/${PN}.git"
 
 DESCRIPTION="Next generation of build systems based on Qt and QML language/"
 LICENSE="LGPL-2"

--- a/media-plugins/deadbeef-bs2b/deadbeef-bs2b-9999.ebuild
+++ b/media-plugins/deadbeef-bs2b/deadbeef-bs2b-9999.ebuild
@@ -8,7 +8,7 @@ inherit eutils git-2
 
 DESCRIPTION="bs2b DSP plugin for DeaDBeeF, using libbs2b."
 HOMEPAGE="https://gitorious.org/deadbeef-sm-plugins/bs2b"
-EGIT_REPO_URI="git://gitorious.org/deadbeef-sm-plugins/bs2b.git"
+EGIT_REPO_URI="https://gitorious.org/deadbeef-sm-plugins/bs2b.git"
 
 LICENSE="MIT"
 SLOT="0"

--- a/media-plugins/deadbeef-jack/deadbeef-jack-9999.ebuild
+++ b/media-plugins/deadbeef-jack/deadbeef-jack-9999.ebuild
@@ -8,7 +8,7 @@ inherit eutils git-2
 
 DESCRIPTION="JACK output plugin for DeaDBeeF."
 HOMEPAGE="https://gitorious.org/deadbeef-sm-plugins/jack"
-EGIT_REPO_URI="git://gitorious.org/deadbeef-sm-plugins/jack.git"
+EGIT_REPO_URI="https://gitorious.org/deadbeef-sm-plugins/jack.git"
 
 LICENSE="MIT"
 SLOT="0"

--- a/media-plugins/deadbeef-stereo-widener/deadbeef-stereo-widener-9999.ebuild
+++ b/media-plugins/deadbeef-stereo-widener/deadbeef-stereo-widener-9999.ebuild
@@ -8,7 +8,7 @@ inherit eutils git-2
 
 DESCRIPTION="A simple stereo widener plugin for DeaDBeeF."
 HOMEPAGE="https://gitorious.org/deadbeef-sm-plugins/stereo-widener"
-EGIT_REPO_URI="git://gitorious.org/deadbeef-sm-plugins/stereo-widener.git"
+EGIT_REPO_URI="https://gitorious.org/deadbeef-sm-plugins/stereo-widener.git"
 
 LICENSE="MIT"
 SLOT="0"

--- a/media-sound/amulet/amulet-9999.ebuild
+++ b/media-sound/amulet/amulet-9999.ebuild
@@ -8,7 +8,7 @@ inherit qt4-r2 git-r3
 
 DESCRIPTION="Audio converter based on flac, lame..."
 HOMEPAGE="http://gitorious.org/amulet"
-EGIT_REPO_URI="git://gitorious.org/amulet/amulet.git"
+EGIT_REPO_URI="https://gitorious.org/amulet/amulet.git"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-sound/qsmmp/qsmmp-9999.ebuild
+++ b/media-sound/qsmmp/qsmmp-9999.ebuild
@@ -6,7 +6,7 @@ EAPI="4"
 inherit qt4-r2 git-2
 
 HOMEPAGE="http://gitorious.org/qsmmp"
-EGIT_REPO_URI="git://gitorious.org/qsmmp/${PN}.git"
+EGIT_REPO_URI="https://gitorious.org/qsmmp/${PN}.git"
 EGIT_BRANCH="qmmp-9999"
 EGIT_COMMIT="${EGIT_BRANCH}"
 

--- a/x11-libs/qt-components-desktop/qt-components-desktop-9999.ebuild
+++ b/x11-libs/qt-components-desktop/qt-components-desktop-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI="2"
 
-EGIT_REPO_URI="git://gitorious.org/qtplayground/qtdesktopcomponents.git"
+EGIT_REPO_URI="https://gitorious.org/qtplayground/qtdesktopcomponents.git"
 EGIT_BRANCH="qt4"
 
 inherit qt4-r2 git-2


### PR DESCRIPTION
Right now, gitorious.org is a read-only mirror of the former site and it no longer supports the git:// protocol, so we switch to https:// .